### PR TITLE
Fix: Breaking version logic for acorn case in kangaroo

### DIFF
--- a/src/main/filesystem.ts
+++ b/src/main/filesystem.ts
@@ -150,6 +150,15 @@ export function breakingAppVersion(): string {
   return breakingVersion(version);
 }
 
+/**
+ * IMPORTANT: For Acorn specifically we consider minor versions as breaking
+ * versions. This allows us to depict version changes (minor) that allow
+ * for forward-migration while still using dedicated databases locations
+ * for different minor versions.
+ *
+ * @param version version string
+ * @returns
+ */
 export function breakingVersion(version: string): string {
   if (!semver.valid(version)) {
     throw new Error('App has an invalid version number.');
@@ -169,7 +178,9 @@ export function breakingVersion(version: string): string {
           return `0.${semver.minor(version)}.x`;
       }
     default:
-      return `${semver.major(version)}.x.x`;
+      // This is line below has been changed for Acorn and deviates
+      // from the upstream kangaroo
+      return `${semver.major(version)}.${semver.minor(version)}.x`;
   }
 }
 


### PR DESCRIPTION
### Summary

This adapts the breaking version logic of kangaroo to the acorn special case. For acorn we want different minor versions, e.g. `11.2.0` and `11.3.0` to be stored in different folders since they may be associated to different holochain versions. But they are no major breaking changes necessarily because there is an automated forward-migration path between them.

### TODO:
- [ ] CHANGELOG mentions all code changes.
