### PR TITLE
Change binary appendix

### DIFF
--- a/scripts/fetch-binaries.js
+++ b/scripts/fetch-binaries.js
@@ -35,7 +35,7 @@ switch (process.platform) {
     throw new Error(`Got unexpected OS platform: ${process.platform}`);
 }
 
-const binariesAppendix = kangarooConfig.appId.slice(0, 10).replace(' ', '-');
+const binariesAppendix = `acorn-${kangarooConfig.version}`;
 
 const holochainBinaryFilename = `holochain-v${
   kangarooConfig.bins.holochain.version

--- a/src/main/const.ts
+++ b/src/main/const.ts
@@ -20,7 +20,7 @@ const conductorConfigTemplateString = fs.readFileSync(
 );
 export const CONDUCTOR_CONFIG_TEMPLATE = yaml.load(conductorConfigTemplateString);
 
-const binariesAppendix = KANGAROO_CONFIG.appId.slice(0, 10).replace(' ', '-');
+const binariesAppendix = `acorn-${KANGAROO_CONFIG.version}`;
 
 const BINARIES_DIRECTORY = path.join(RESOURCES_DIRECTORY, 'bins');
 


### PR DESCRIPTION
### Summary

Process names get trimmed on linux. To be able to still compare acorn holochain processes from holochain processes of other lightningrodlabs apps this PR changes the binary appendix. Previously processes would have been for example been called `holochain-0.5.2-org.lightn` both for Moss and Acorn.

### TODO:
- [ ] CHANGELOG mentions all code changes.
